### PR TITLE
Fix trailing empty voice name

### DIFF
--- a/server.go
+++ b/server.go
@@ -198,8 +198,8 @@ func voicesHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		voices := new(Voices)
-		// leave out the header value
-		voices.Names = strings.Split(voicesBuf.String(), "\n")[1:]
+		// leave out the header value and trailing empty line
+		voices.Names = strings.Split(strings.TrimSpace(voicesBuf.String()), "\n")[1:]
 
 		js, err := json.Marshal(voices)
 		if err != nil {


### PR DESCRIPTION
## Summary
- avoid returning a blank voice name by trimming `--voices` output

## Testing
- `go build server.go`
- `go vet server.go`


------
https://chatgpt.com/codex/tasks/task_e_685b198a70c483289f580a2ca3831025