### PR TITLE
Fix typo in server.go comment

### DIFF
--- a/server.go
+++ b/server.go
@@ -117,7 +117,7 @@ func buildEncodeCmd(values *url.Values, w *http.ResponseWriter) (cmd *exec.Cmd, 
 }
 
 // Handles a request for synthesized speech. Build the synthesizer and encoder
-// comands. Pipe the first to the second. Pipe the encoded stream out as the
+// commands. Pipe the first to the second. Pipe the encoded stream out as the
 // response. Supports URL arguments:
 // text: string to synthesize (required)
 // pitch: [0, 99] default: 50


### PR DESCRIPTION
## Summary
- fix small typo in comment above `speechHandler`

## Testing
- `GO111MODULE=off go fmt ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c3e868100832884df98c7b2022bb9