### PR TITLE
Update encoding options in API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ GET /speech?text=<utterance>
             [&pitch=<0,99; default 50>]
             [&speed=<80,450; default 175 wpm>]
             [&voice=<name; default en>]
-            [&encoding=<mp3|opus; default mp3>]
+            [&encoding=<mp3|opus|wav; default mp3>]
 ```
 
 Response:


### PR DESCRIPTION
## Summary
- document `wav` as a valid encoding option

## Testing
- `go test ./...` *(fails: directory prefix does not contain module)*

------
https://chatgpt.com/codex/tasks/task_e_685c3e8b064c832885101cda9035648a